### PR TITLE
Fix heritrix spelling

### DIFF
--- a/Tools.org
+++ b/Tools.org
@@ -7,16 +7,16 @@ We've been collaborating via [[http://www.slack.com][Slack]] and [[http://github
 
 The EOT project has a simple bookmarklet for nominating "seeds" for their webcrawler; you can [[http://digital2.library.unt.edu/nomination/eth2016/about/][read about it here]]. For our event we derived a [[https://github.com/CivicTechTO/presidential-harvest-nomination-tool][Chrome Extension]], and would recommend its use to future groups.
 * Scrapers
-We expectto use [[https://scrapy.org/][the scrapy Python library]] and maybe its GUI companion [[https://scrapinghub.com/portia/][portia]] for this work.
+We expect to use [[https://scrapy.org/][the scrapy Python library]] and maybe its GUI companion [[https://scrapinghub.com/portia/][portia]] for this work.
 * Crawlers
 :PROPERTIES:
 :CUSTOM_ID: crawlers
 :END:
-The IA uses [[http://crawler.archive.org/index.html][Heritrix]] for its crawl, but it is a little finicky to set up and somewhat complex to learn to use, so we are not using it at our event.  Instead, we will have to code our own.  THere are basically two technical specifications:
+The IA uses [[http://crawler.archive.org/index.html][Heritrix]] for its crawl, but it is a little finicky to set up and somewhat complex to learn to use, so we are not using it at our event.  Instead, we will have to code our own.  There are basically two technical specifications:
 - any tool we use should respect robots.txt
 - Any archives we produce should be in WARC format, the ISO standard for web archives used by the Internet Archive.  
 
-One simple solution seems to be [[https://github.com/odie5533/WarcMiddleware][WARC Middleware]], which can accept a list of URL's in a file.  As I understand it Scrapy obeys robots.txt if the variable assignment ~ROBOTSTXT_OBEY = True~ is included in the file.
+One simple solution seems to be [[https://github.com/odie5533/WarcMiddleware][WARC Middleware]], which can accept a list of URLs in a file.  As I understand it Scrapy obeys robots.txt if the variable assignment ~ROBOTSTXT_OBEY = True~ is included in the file.
 
 Another suggestion we've gotten is [[https://github.com/ludios/grab-site][grab-site]], which came to us via the maintainers of [[https://webrecorder.io/][webrecorder]].  
 

--- a/Tools.org
+++ b/Tools.org
@@ -12,7 +12,7 @@ We expectto use [[https://scrapy.org/][the scrapy Python library]] and maybe its
 :PROPERTIES:
 :CUSTOM_ID: crawlers
 :END:
-The IA uses [[http://crawler.archive.org/index.html][Heretrix]] for its crawl, but it is a little finicky to set up and somewhat complex to learn to use, so we are not using it at our event.  Instead, we will have to code our own.  THere are basically two technical specifications:
+The IA uses [[http://crawler.archive.org/index.html][Heritrix]] for its crawl, but it is a little finicky to set up and somewhat complex to learn to use, so we are not using it at our event.  Instead, we will have to code our own.  THere are basically two technical specifications:
 - any tool we use should respect robots.txt
 - Any archives we produce should be in WARC format, the ISO standard for web archives used by the Internet Archive.  
 

--- a/what-heretrix-does.org
+++ b/what-heretrix-does.org
@@ -12,7 +12,7 @@
 #+EXCLUDE_TAGS: noexport
 #+CREATOR: Emacs 26.0.50.1 (Org mode 9.0.1)
 
-Our nomination tool asks the Internet Archive webcrawler, [[https://github.com/internetarchive/heritrix3][Heritrix]], to start deeper crawls from URL's that are buried 2-3 clicks down in a website's link hierarchy.  In this document we explain a little bit about what Heritrix can do, why it needs our help, and also how to identify documents and datasets that Heritrix *can't* reach.  
+Our nomination tool asks the Internet Archive webcrawler, [[https://github.com/internetarchive/heritrix3][Heritrix]], to start deeper crawls from URLs that are buried 2-3 clicks down in a website's link hierarchy.  In this document we explain a little bit about what Heritrix can do, why it needs our help, and also how to identify documents and datasets that Heritrix *can't* reach.  
 
 * How a webcrawler works
 A webcrawler like Heritrix reads web pages and searches for links.  When it finds a link, it follows it to a new page, where it once again searches for links, and then follows those, and so on, and so on...  As you can imagine, this rapidly leads to a *very* large number of links!  the Internet Archive therefore imposes limits on Heritrix: after a certain number of "hops", it will stop collecting links and move on to the next "seed" in its list.  This allows it to cover a lot of "territory" -- moving relatively rapidly through the huge ~.gov~ domain -- but it means that there are "hidden depths" which it doesn't see.  
@@ -20,7 +20,7 @@ A webcrawler like Heritrix reads web pages and searches for links.  When it find
 When we nominate seeds, we draw Heritrix's attention to some of this "deep web" -- identifying it as especially important, and worth crawling.  This is important work, and we're grateful for the volunteers that help us to do it.
 
 * What Heritrix can and can't get
-Heritrix is a clever program, but it runs in a "command-line" environment, and is fully automated. That means that there are certain things it can't do. On the other hand, what it can do, it odes very well.  
+Heritrix is a clever program, but it runs in a "command-line" environment, and is fully automated. That means that there are certain things it can't do. On the other hand, what it can do, it does very well.  
 
 Heritrix can:
 - browse any "http://" or "https://" link that it finds.  This includes zip files, excel files, pdfs, etc. - -as long as the link you see is *really* a link to the file, and not an "obfuscated" link that instead points to a page that includes a complex environment (see below).
@@ -28,14 +28,14 @@ Heritrix can:
 But here are some things that Heritrix can't do:
 - it can't click "Go!" or "Submit" on a web form -- so search forms tend to stop it pretty much dead in its tracks, unless there's a "browse" link also that links to the full list of searchable resources
 - It doesn't have a sophisticated browser environment that can do computing work for it.  Many sophisticated webpages ask the browser to do a lot of computational work.  Heritrix can't do that very well.
-- It also can't follow links that don't use the "http protocol".  This mostly affects resources that aren't designed for direct browsing.  There are at least two important sub-categories here:
-  - *FTP links:* the "File transfer protocol" predates the Web, and government agencies still use FTP for many static resources, like zipfiles of quantitative datasets.  Heritrix just doesn't Have a way to deal with these resources so will *never* capture them.
+- It also can't follow links that don't use the Hypertext Transfer Protocol (HTTP).  This mostly affects resources that aren't designed for direct browsing.  There are at least two important sub-categories here:
+  - *FTP links:* the File Transfer Protocol predates the Web, and government agencies still use FTP for many static resources, like zip files of quantitative datasets.  Heritrix just doesn't have a way to deal with these resources so will *never* capture them.
   - *Complicated Databases:* Many of the most important resources on government websites use maps or other fancy interfaces to display government data in a user-friendly form. In order to get that data, the webpage has to request it from a database.  Those requests don't go over http, and they also usually aren't visible to the browser at all. So if the database goes offline, the fancy interface will be useless.  The Internet Archive will still have a copy of the web page, but it will just display an empty box in the middle where the fancy map is supposed to be.  
 
 So one important task you can help with, is identifying these un-crawlable database interfaces and alerting us (the project, not the webcrawler) to their location.  Once we know about them, we can try to "reverse engineer" the interface -- look for clues that identify the underlying data, and try to preserve it somehow, either by coding tricks, or through some other preservation avenue (such as an FOIA request or a manual download at a government library).
 
 ** Identifying Un-crawlable data
-Let's look at one example of a difficult-to-crawl site.  The [[https://www.epa.gov/nscep][EPA's publication search form]] leads to [[https://nepis.epa.gov/Exe/ZyNET.exe?User=ANONYMOUS&Back=ZyActionL&BackDesc=Contents+page&Client=EPA&DefSeekPage=x&Display=hpfr&Docs=&ExtQFieldOp=0&File=&FuzzyDegree=0&ImageQuality=r85g16%2Fr85g16%2Fx150y150g16%2Fi500&Index=1976+Thru+1980|1981+Thru+1985|2000+Thru+2005|Hardcopy+Publications|2011+Thru+2015|Prior+to+1976|1991+Thru+1994|1995+Thru+1999|2006+Thru+2010|1986+Thru+1990&IndexPresets=entry&IntQFieldOp=0&MaximumDocuments=15&MaximumPages=1&Password=anonymous&QField=&QFieldDay=&QFieldMonth=&QFieldYear=&Query=climate%20&SearchBack=ZyActionL&SearchMethod=2&SeekPage=&SortMethod=-&SortMethod=h&Time=&Toc=&TocEntry=&TocRestrict=n&UseQField=&ZyAction=ZyActionS&ZyEntry=0][results pages like this one]].  If you [[https://nepis.epa.gov/Exe/ZyNET.exe/P100OW3T.txt?ZyActionD=ZyDocument&Client=EPA&Index=1976%20Thru%201980%7C1981%20Thru%201985%7C2000%20Thru%202005%7CHardcopy%20Publications%7C2011%20Thru%202015%7CPrior%20to%201976%7C1991%20Thru%201994%7C1995%20Thru%201999%7C2006%20Thru%202010%7C1986%20Thru%201990&Docs=&Query=climate%20&Time=&EndTime=&SearchMethod=2&TocRestrict=n&Toc=&TocEntry=&QField=&QFieldYear=&QFieldMonth=&QFieldDay=&UseQField=&IntQFieldOp=0&ExtQFieldOp=0&XmlQuery=&File=D%3A%5CZYFILES%5CINDEX%20DATA%5C11THRU15%5CTXT%5C00000020%5CP100OW3T.txt&User=ANONYMOUS&Password=anonymous&SortMethod=-%7Ch&MaximumDocuments=15&FuzzyDegree=0&ImageQuality=r85g16/r85g16/x150y150g16/i500&Display=hpfr&DefSeekPage=x&SearchBack=ZyActionL&Back=ZyActionS&BackDesc=Results%20page&MaximumPages=1&ZyEntry=1&SeekPage=x][open one of the actual results i na new tab]], you'll be able to follow along with the rest of this section.  
+Let's look at one example of a difficult-to-crawl site.  The [[https://www.epa.gov/nscep][EPA's publication search form]] leads to [[https://nepis.epa.gov/Exe/ZyNET.exe?User=ANONYMOUS&Back=ZyActionL&BackDesc=Contents+page&Client=EPA&DefSeekPage=x&Display=hpfr&Docs=&ExtQFieldOp=0&File=&FuzzyDegree=0&ImageQuality=r85g16%2Fr85g16%2Fx150y150g16%2Fi500&Index=1976+Thru+1980|1981+Thru+1985|2000+Thru+2005|Hardcopy+Publications|2011+Thru+2015|Prior+to+1976|1991+Thru+1994|1995+Thru+1999|2006+Thru+2010|1986+Thru+1990&IndexPresets=entry&IntQFieldOp=0&MaximumDocuments=15&MaximumPages=1&Password=anonymous&QField=&QFieldDay=&QFieldMonth=&QFieldYear=&Query=climate%20&SearchBack=ZyActionL&SearchMethod=2&SeekPage=&SortMethod=-&SortMethod=h&Time=&Toc=&TocEntry=&TocRestrict=n&UseQField=&ZyAction=ZyActionS&ZyEntry=0][results pages like this one]].  If you [[https://nepis.epa.gov/Exe/ZyNET.exe/P100OW3T.txt?ZyActionD=ZyDocument&Client=EPA&Index=1976%20Thru%201980%7C1981%20Thru%201985%7C2000%20Thru%202005%7CHardcopy%20Publications%7C2011%20Thru%202015%7CPrior%20to%201976%7C1991%20Thru%201994%7C1995%20Thru%201999%7C2006%20Thru%202010%7C1986%20Thru%201990&Docs=&Query=climate%20&Time=&EndTime=&SearchMethod=2&TocRestrict=n&Toc=&TocEntry=&QField=&QFieldYear=&QFieldMonth=&QFieldDay=&UseQField=&IntQFieldOp=0&ExtQFieldOp=0&XmlQuery=&File=D%3A%5CZYFILES%5CINDEX%20DATA%5C11THRU15%5CTXT%5C00000020%5CP100OW3T.txt&User=ANONYMOUS&Password=anonymous&SortMethod=-%7Ch&MaximumDocuments=15&FuzzyDegree=0&ImageQuality=r85g16/r85g16/x150y150g16/i500&Display=hpfr&DefSeekPage=x&SearchBack=ZyActionL&Back=ZyActionS&BackDesc=Results%20page&MaximumPages=1&ZyEntry=1&SeekPage=x][open one of the actual results in a new tab]], you'll be able to follow along with the rest of this section.  
 
 This is quite a pretty-looking page, in some ways, but there are *two red flags* that suggest that the important data won't be preserved by an IA webcrawl. 
 
@@ -46,13 +46,13 @@ This is quite a pretty-looking page, in some ways, but there are *two red flags*
 
 So by capturing the page content, we'll only have archived a single page of the document rather than the document itself!
 
-- *second,* while there is a "link" of sorts to the PDF and text documents, they aren't "real" links.  Instead, they are javascript *commands* which open new browser windows and dynamically gneerate the URL's for the requested documents.  
+- *second,* while there is a "link" of sorts to the PDF and text documents, they aren't "real" links.  Instead, they are javascript *commands* which open new browser windows and dynamically generate the URLs for the requested documents.  
 
 You can verify this in two ways.  First, "inspect element" on the "PDF" link, and you'll see that it looks like this:
 #+BEGIN_SRC html
 <a href="#" title="Download this document as a PDF" alt="Download this document as a PDF" onclick="ZyShowPDF('PDF',event)">PDF</a>
 #+END_SRC
-Heritrix can't get capture links of this kind.
+Heritrix can't capture links of this kind.
 
 The other way to confirm this is by clicking on the link and paying attention while the pdf loads in the new window.  Instead of loading right away, the page first gives you a fancy loading screen.  This means that some kind of communication is happening between your browser and the server while you wait. Heritrix can't talk to the server like your browser can! So the capture will fail and the really important document -- the actual resource! -- won't be archived.
 

--- a/what-heretrix-does.org
+++ b/what-heretrix-does.org
@@ -3,7 +3,7 @@
 #+OPTIONS: date:t e:t email:nil f:t inline:t num:nil p:nil pri:nil
 #+OPTIONS: prop:nil stat:t tags:t tasks:t tex:t timestamp:t title:t
 #+OPTIONS: toc:nil todo:t |:t
-#+TITLE: Understanding What Heretrix Does
+#+TITLE: Understanding What Heritrix Does
 #+DATE: <2016-12-20 Tue>
 #+AUTHOR: Matt Price
 #+EMAIL: matt.price@utoronto.ca
@@ -12,24 +12,24 @@
 #+EXCLUDE_TAGS: noexport
 #+CREATOR: Emacs 26.0.50.1 (Org mode 9.0.1)
 
-Our nomination tool asks the Internet Archive webcrawler, [[https://github.com/internetarchive/heritrix3][Heretrix]], to start deeper crawls from URL's that are buried 2-3 clicks down in a website's link hierarchy.  In this document we explain a little bit about what Heretrix can do, why it needs our help, and also how to identify documents and datasets that Heretrix *can't* reach.  
+Our nomination tool asks the Internet Archive webcrawler, [[https://github.com/internetarchive/heritrix3][Heritrix]], to start deeper crawls from URL's that are buried 2-3 clicks down in a website's link hierarchy.  In this document we explain a little bit about what Heritrix can do, why it needs our help, and also how to identify documents and datasets that Heritrix *can't* reach.  
 
 * How a webcrawler works
-A webcrawler like Heretrix reads web pages and searches for links.  When it finds a link, it follows it to a new page, where it once again searches for links, and then follows those, and so on, and so on...  As you can imagine, this rapidly leads to a *very* large number of links!  the Internet Archive therefore imposes limits on Heretrix: after a certain number of "hops", it will stop collecting links and move on to the next "seed" in its list.  This allows it to cover a lot of "territory" -- moving relatively rapidly through the huge ~.gov~ domain -- but it means that there are "hidden depths" which it doesn't see.  
+A webcrawler like Heritrix reads web pages and searches for links.  When it finds a link, it follows it to a new page, where it once again searches for links, and then follows those, and so on, and so on...  As you can imagine, this rapidly leads to a *very* large number of links!  the Internet Archive therefore imposes limits on Heritrix: after a certain number of "hops", it will stop collecting links and move on to the next "seed" in its list.  This allows it to cover a lot of "territory" -- moving relatively rapidly through the huge ~.gov~ domain -- but it means that there are "hidden depths" which it doesn't see.  
 
-When we nominate seeds, we draw Heretrix's attention to some of this "deep web" -- identifying it as especially important, and worth crawling.  This is important work, and we're grateful for the volunteers that help us to do it.
+When we nominate seeds, we draw Heritrix's attention to some of this "deep web" -- identifying it as especially important, and worth crawling.  This is important work, and we're grateful for the volunteers that help us to do it.
 
-* What Heretrix can and can't get
-Heretrix is a clever program, but it runs in a "command-line" environment, and is fully automated. That means that there are certain things it can't do. On the other hand, what it can do, it odes very well.  
+* What Heritrix can and can't get
+Heritrix is a clever program, but it runs in a "command-line" environment, and is fully automated. That means that there are certain things it can't do. On the other hand, what it can do, it odes very well.  
 
-Heretrix can:
+Heritrix can:
 - browse any "http://" or "https://" link that it finds.  This includes zip files, excel files, pdfs, etc. - -as long as the link you see is *really* a link to the file, and not an "obfuscated" link that instead points to a page that includes a complex environment (see below).
 
-But here are some things that Heretrix can't do:
+But here are some things that Heritrix can't do:
 - it can't click "Go!" or "Submit" on a web form -- so search forms tend to stop it pretty much dead in its tracks, unless there's a "browse" link also that links to the full list of searchable resources
-- It doesn't have a sophisticated browser environment that can do computing work for it.  Many sophisticated webpages ask the browser to do a lot of computational work.  Heretrix can't do that very well.
+- It doesn't have a sophisticated browser environment that can do computing work for it.  Many sophisticated webpages ask the browser to do a lot of computational work.  Heritrix can't do that very well.
 - It also can't follow links that don't use the "http protocol".  This mostly affects resources that aren't designed for direct browsing.  There are at least two important sub-categories here:
-  - *FTP links:* the "File transfer protocol" predates the Web, and government agencies still use FTP for many static resources, like zipfiles of quantitative datasets.  Heretrix just doesn't Have a way to deal with these resources so will *never* capture them.
+  - *FTP links:* the "File transfer protocol" predates the Web, and government agencies still use FTP for many static resources, like zipfiles of quantitative datasets.  Heritrix just doesn't Have a way to deal with these resources so will *never* capture them.
   - *Complicated Databases:* Many of the most important resources on government websites use maps or other fancy interfaces to display government data in a user-friendly form. In order to get that data, the webpage has to request it from a database.  Those requests don't go over http, and they also usually aren't visible to the browser at all. So if the database goes offline, the fancy interface will be useless.  The Internet Archive will still have a copy of the web page, but it will just display an empty box in the middle where the fancy map is supposed to be.  
 
 So one important task you can help with, is identifying these un-crawlable database interfaces and alerting us (the project, not the webcrawler) to their location.  Once we know about them, we can try to "reverse engineer" the interface -- look for clues that identify the underlying data, and try to preserve it somehow, either by coding tricks, or through some other preservation avenue (such as an FOIA request or a manual download at a government library).
@@ -52,9 +52,9 @@ You can verify this in two ways.  First, "inspect element" on the "PDF" link, an
 #+BEGIN_SRC html
 <a href="#" title="Download this document as a PDF" alt="Download this document as a PDF" onclick="ZyShowPDF('PDF',event)">PDF</a>
 #+END_SRC
-Heretrix can't get capture links of this kind.
+Heritrix can't get capture links of this kind.
 
-The other way to confirm this is by clicking on the link and paying attention while the pdf loads in the new window.  Instead of loading right away, the page first gives you a fancy loading screen.  This means that some kind of communication is happening between your browser and the server while you wait. Heretrix can't talk to the server like your browser can! So the capture will fail and the really important document -- the actual resource! -- won't be archived.
+The other way to confirm this is by clicking on the link and paying attention while the pdf loads in the new window.  Instead of loading right away, the page first gives you a fancy loading screen.  This means that some kind of communication is happening between your browser and the server while you wait. Heritrix can't talk to the server like your browser can! So the capture will fail and the really important document -- the actual resource! -- won't be archived.
 
 In these cases, *follow the instructions above to notify the tech team that you've found something the webcrawler can't archive!*
 * How to Nominate Seeds


### PR DESCRIPTION
Heritrix was spelled incorrectly throughout. This changes that and a few other typos.

Technically, I think the what-heretrix-does.org document is pretty accurate, although, Heritrix actually can technically capture FTP URLs if configured to do so, but the archived results aren't necessarily as usable as with HTTP (such as at the directory index level).